### PR TITLE
Fixes for Buster on a Pi Zero W

### DIFF
--- a/ansible/roles/hkcam/tasks/configure.yml
+++ b/ansible/roles/hkcam/tasks/configure.yml
@@ -73,7 +73,7 @@
 
 - name: Download v4l2loopback
   get_url:
-     url: https://github.com/umlaeute/v4l2loopback/archive/v0.12.2.tar.gz
+     url: https://github.com/umlaeute/v4l2loopback/archive/v0.12.3.tar.gz
      dest: /tmp
   register: v4l2_pkg_download
 
@@ -97,8 +97,3 @@
     dest: /etc/modules
     regexp: "^v4l2loopback"
     line: "v4l2loopback"
-
-- name: Add v4l2loopback module configuration
-  copy:
-    content: "options v4l2loopback video_nr=1"
-    dest: /etc/modprobe.d/v4l2loopback.conf

--- a/ansible/roles/hkcam/tasks/configure.yml
+++ b/ansible/roles/hkcam/tasks/configure.yml
@@ -73,7 +73,7 @@
 
 - name: Download v4l2loopback
   get_url:
-     url: https://github.com/umlaeute/v4l2loopback/archive/v0.12.3.tar.gz
+     url: https://github.com/umlaeute/v4l2loopback/archive/v0.12.5.tar.gz
      dest: /tmp
   register: v4l2_pkg_download
 


### PR DESCRIPTION
With these changes, the playbook works for me on a Pi Zero W with Raspbian Buster (freshly installed on the date I tested this out).