### PR TITLE
#150 Update syntax for Ansible v2

### DIFF
--- a/ansible/roles/hkcam/tasks/main.yml
+++ b/ansible/roles/hkcam/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: install.yml
+- include_tasks: install.yml
   tags: [install]
 
-- include: configure.yml
+- include_tasks: configure.yml
   tags: [configure]
 
 - import_role:

--- a/ansible/roles/runit/tasks/install.yml
+++ b/ansible/roles/runit/tasks/install.yml
@@ -11,7 +11,7 @@
   file: path={{ runit_runsvdir_dir }} mode=0755 state=directory
 
 - name: Check if {{ runit_startup_file }} exists
-  stat: path={{ runit_startup_file }} get_md5=no get_checksum=no
+  stat: path={{ runit_startup_file }} get_checksum=no
   register: file
 
 - name: Create startup script at {{ runit_startup_file }}
@@ -33,4 +33,4 @@
   shell: sed -i -e '$i {{ runit_startup_file }} &\n' /etc/rc.local
   args:
       warn: false
-  when: check.rc != 0
+  when: check is defined and check.rc is defined and check.rc != 0

--- a/ansible/roles/runit/tasks/main.yml
+++ b/ansible/roles/runit/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- include: install.yml
+- include_tasks: install.yml
 
-- include: add.yml
+- include_tasks: add.yml
   when: service_name is defined
 
-- include: enabled.yml
+- include_tasks: enabled.yml
   when: enabled is defined and service_name is defined
 
-- include: envs.yml
+- include_tasks: envs.yml
   when: envs is defined and service_name is defined
 
-- include: state.yml
+- include_tasks: state.yml
   when: state is defined and service_name is defined


### PR DESCRIPTION
Resolves #150 

- [x] Update `include` to `include_tasks`

Note: I also added extra checks in `Add line to launch runit on startup` as it was breaking for me at `check.rc != 0`. And apparently `get_md5=no` is no longer a thing.

Running on:
* Raspberry Pi 5
* Debian version: 12 (bookworm)

## Testing steps

1. `cd ansible && ansible-playbook rpi.yml -i hosts`

```bash
$ ansible --version
ansible [core 2.17.6]

$ brew info ansible
==> ansible: stable 10.6.0 (bottled), HEAD
```